### PR TITLE
Add OTLP marshalling support for kinesis exporter

### DIFF
--- a/exporter/kinesisexporter/factory.go
+++ b/exporter/kinesisexporter/factory.go
@@ -27,7 +27,7 @@ const (
 	// The value of "type" key in configuration.
 	typeStr         = "kinesis"
 	defaultEncoding = "jaeger-proto"
-	otlp_proto      = "otlp_proto"
+	otlpProto       = "otlp_proto"
 )
 
 // NewFactory creates a factory for Kinesis exporter.

--- a/exporter/kinesisexporter/factory.go
+++ b/exporter/kinesisexporter/factory.go
@@ -26,7 +26,7 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr         = "kinesis"
-	defaultEncoding = "jaeger-proto"
+	exportFormat = "jaeger-proto"
 	otlpProto       = "otlp_proto"
 )
 
@@ -91,7 +91,7 @@ func createTraceExporter(
 		MaxAllowedSizePerSpan: c.MaxBytesPerSpan,
 		MaxListSize:           c.MaxBytesPerBatch,
 		ListFlushInterval:     c.FlushIntervalSeconds,
-		Encoding:              defaultEncoding,
+		Encoding:              exportFormat,
 	}, params.Logger)
 	if err != nil {
 		return nil, err

--- a/exporter/kinesisexporter/factory.go
+++ b/exporter/kinesisexporter/factory.go
@@ -25,8 +25,8 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr      = "kinesis"
-	exportFormat = "jaeger-proto"
+	typeStr         = "kinesis"
+	defaultEncoding = "otlp_proto"
 )
 
 // NewFactory creates a factory for Kinesis exporter.
@@ -90,7 +90,7 @@ func createTraceExporter(
 		MaxAllowedSizePerSpan: c.MaxBytesPerSpan,
 		MaxListSize:           c.MaxBytesPerBatch,
 		ListFlushInterval:     c.FlushIntervalSeconds,
-		Encoding:              exportFormat,
+		Encoding:              defaultEncoding,
 	}, params.Logger)
 	if err != nil {
 		return nil, err

--- a/exporter/kinesisexporter/factory.go
+++ b/exporter/kinesisexporter/factory.go
@@ -25,9 +25,9 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr         = "kinesis"
+	typeStr      = "kinesis"
 	exportFormat = "jaeger-proto"
-	otlpProto       = "otlp_proto"
+	otlpProto    = "otlp_proto"
 )
 
 // NewFactory creates a factory for Kinesis exporter.

--- a/exporter/kinesisexporter/factory.go
+++ b/exporter/kinesisexporter/factory.go
@@ -26,7 +26,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr         = "kinesis"
-	defaultEncoding = "otlp_proto"
+	defaultEncoding = "jaeger-proto"
+	otlp_proto      = "otlp_proto"
 )
 
 // NewFactory creates a factory for Kinesis exporter.

--- a/exporter/kinesisexporter/marshaller.go
+++ b/exporter/kinesisexporter/marshaller.go
@@ -21,7 +21,7 @@ import (
 // Marshaller marshals traces/metrics into Message array.
 type Marshaller interface {
 	// MarshalMetrics serializes metrics into Messages
-	MarshalMetrics(metrics pdata.Metrics) (Message, error)
+	MarshalMetrics(metrics pdata.Metrics) ([]byte, error)
 
 	// Encoding returns encoding name
 	Encoding() string

--- a/exporter/kinesisexporter/marshaller.go
+++ b/exporter/kinesisexporter/marshaller.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kinesisexporter
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// Marshaller marshals traces/metrics into Message array.
+type Marshaller interface {
+	// MarshalMetrics serializes metrics into Messages
+	MarshalMetrics(metrics pdata.Metrics) (Message, error)
+
+	// Encoding returns encoding name
+	Encoding() string
+}
+
+// Message encapsulates Kinesis' message payload.
+type Message struct {
+	Value []byte
+}
+
+// defaultMarshallers returns map of supported encodings with Marshaller.
+func defaultMarshallers() map[string]Marshaller {
+	otlp := &otlpProtoMarshaller{}
+	return map[string]Marshaller{
+		otlp.Encoding():        otlp,
+	}
+}

--- a/exporter/kinesisexporter/marshaller.go
+++ b/exporter/kinesisexporter/marshaller.go
@@ -36,6 +36,6 @@ type Message struct {
 func defaultMarshallers() map[string]Marshaller {
 	otlp := &otlpProtoMarshaller{}
 	return map[string]Marshaller{
-		otlp.Encoding():        otlp,
+		otlp.Encoding(): otlp,
 	}
 }

--- a/exporter/kinesisexporter/marshaller_test.go
+++ b/exporter/kinesisexporter/marshaller_test.go
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kinesisexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultMarshallers(t *testing.T) {
+	expectedEncodings := []string{
+		"otlp_proto",
+	}
+	marshallers := defaultMarshallers()
+	assert.Equal(t, len(expectedEncodings), len(marshallers))
+	for _, e := range expectedEncodings {
+		t.Run(e, func(t *testing.T) {
+			m, ok := marshallers[e]
+			require.True(t, ok)
+			assert.NotNil(t, m)
+		})
+	}
+}

--- a/exporter/kinesisexporter/otlp_marshaller.go
+++ b/exporter/kinesisexporter/otlp_marshaller.go
@@ -24,13 +24,9 @@ type otlpProtoMarshaller struct {
 var _ Marshaller = (*otlpProtoMarshaller)(nil)
 
 func (m *otlpProtoMarshaller) Encoding() string {
-	return defaultEncoding
+	return otlp_proto
 }
 
-func (m *otlpProtoMarshaller) MarshalMetrics(metrics pdata.Metrics) (Message, error) {
-	bts, err := metrics.ToOtlpProtoBytes()
-	if err != nil {
-		return Message{}, err
-	}
-	return Message{Value: bts}, nil
+func (m *otlpProtoMarshaller) MarshalMetrics(metrics pdata.Metrics) ([]byte, error) {
+	return metrics.ToOtlpProtoBytes()
 }

--- a/exporter/kinesisexporter/otlp_marshaller.go
+++ b/exporter/kinesisexporter/otlp_marshaller.go
@@ -24,7 +24,7 @@ type otlpProtoMarshaller struct {
 var _ Marshaller = (*otlpProtoMarshaller)(nil)
 
 func (m *otlpProtoMarshaller) Encoding() string {
-	return otlp_proto
+	return otlpProto
 }
 
 func (m *otlpProtoMarshaller) MarshalMetrics(metrics pdata.Metrics) ([]byte, error) {

--- a/exporter/kinesisexporter/otlp_marshaller.go
+++ b/exporter/kinesisexporter/otlp_marshaller.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kinesisexporter
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+type otlpProtoMarshaller struct {
+}
+
+var _ Marshaller = (*otlpProtoMarshaller)(nil)
+
+func (m *otlpProtoMarshaller) Encoding() string {
+	return defaultEncoding
+}
+
+func (m *otlpProtoMarshaller) MarshalMetrics(metrics pdata.Metrics) (Message, error) {
+	bts, err := metrics.ToOtlpProtoBytes()
+	if err != nil {
+		return Message{}, err
+	}
+	return Message{Value: bts}, nil
+}

--- a/exporter/kinesisexporter/otlp_marshaller_test.go
+++ b/exporter/kinesisexporter/otlp_marshaller_test.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kinesisexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestOTLPMetricsMarshaller(t *testing.T) {
+	td := pdata.NewMetrics()
+	td.ResourceMetrics().Resize(1)
+	td.ResourceMetrics().At(0).Resource().InitEmpty()
+	td.ResourceMetrics().At(0).Resource().Attributes().InsertString("foo", "bar")
+	expected, err := td.ToOtlpProtoBytes()
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+
+	m := otlpProtoMarshaller{}
+	assert.Equal(t, "otlp_proto", m.Encoding())
+	messages, err := m.MarshalMetrics(td)
+	require.NoError(t, err)
+	assert.Equal(t, Message{Value: expected}, messages)
+}

--- a/exporter/kinesisexporter/otlp_marshaller_test.go
+++ b/exporter/kinesisexporter/otlp_marshaller_test.go
@@ -33,8 +33,8 @@ func TestOTLPMetricsMarshaller(t *testing.T) {
 	require.NotNil(t, expected)
 
 	m := otlpProtoMarshaller{}
-	assert.Equal(t, "otlp_proto", m.Encoding())
-	messages, err := m.MarshalMetrics(td)
+	assert.Equal(t, otlp_proto, m.Encoding())
+	message, err := m.MarshalMetrics(td)
 	require.NoError(t, err)
-	assert.Equal(t, Message{Value: expected}, messages)
+	assert.Equal(t, expected, message)
 }

--- a/exporter/kinesisexporter/otlp_marshaller_test.go
+++ b/exporter/kinesisexporter/otlp_marshaller_test.go
@@ -33,7 +33,7 @@ func TestOTLPMetricsMarshaller(t *testing.T) {
 	require.NotNil(t, expected)
 
 	m := otlpProtoMarshaller{}
-	assert.Equal(t, otlp_proto, m.Encoding())
+	assert.Equal(t, otlpProto, m.Encoding())
 	message, err := m.MarshalMetrics(td)
 	require.NoError(t, err)
 	assert.Equal(t, expected, message)


### PR DESCRIPTION
**Description:** 
 - Adding a Marshaller interface that allows encoding to different export formats
 - Add an OTLP marshaller with support for metrics
 - NOTE: we could add these otlp marshallers upstream in the core collector i.e. within https://github.com/open-telemetry/opentelemetry-collector/tree/v0.12.0/exporter/exporterhelper since this is essentially similar to the kafka exporter marshallers (potentially part of the submitting upstream PRs effort)

**Testing:**
 - Added unit tests for marshaller and otlp marshaller