### PR TITLE
Integrated marshaller into trace path

### DIFF
--- a/exporter/kinesisexporter/config.go
+++ b/exporter/kinesisexporter/config.go
@@ -47,5 +47,5 @@ type Config struct {
 	AWS AWSConfig `mapstructure:"aws"`
 	KPL KPLConfig `mapstructure:"kpl"`
 
-	ExportFormat string `mapstructure:"export_format"`
+	Encoding string `mapstructure:"encoding"`
 }

--- a/exporter/kinesisexporter/config_test.go
+++ b/exporter/kinesisexporter/config_test.go
@@ -56,6 +56,7 @@ func TestDefaultConfig(t *testing.T) {
 				FlushIntervalSeconds: 5,
 				MaxConnections:       24,
 			},
+			Encoding: defaultEncoding,
 		},
 	)
 }
@@ -97,6 +98,7 @@ func TestConfig(t *testing.T) {
 				MaxRetries:           17,
 				MaxBackoffSeconds:    18,
 			},
+			Encoding: "",
 		},
 	)
 }

--- a/exporter/kinesisexporter/factory.go
+++ b/exporter/kinesisexporter/factory.go
@@ -24,9 +24,9 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr      = "kinesis"
-	exportFormat = "jaeger-proto"
-	otlpProto    = "otlp_proto"
+	typeStr         = "kinesis"
+	otlpProto       = "otlp_proto"
+	defaultEncoding = otlpProto
 )
 
 // NewFactory creates a factory for Kinesis exporter.
@@ -53,7 +53,7 @@ func createDefaultConfig() configmodels.Exporter {
 			FlushIntervalSeconds: 5,
 			MaxConnections:       24,
 		},
-		ExportFormat: "",
+		Encoding: defaultEncoding,
 	}
 }
 

--- a/exporter/kinesisexporter/go.mod
+++ b/exporter/kinesisexporter/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.34.9
+	github.com/google/uuid v1.1.2
 	github.com/signalfx/omnition-kinesis-producer v0.5.0
 	github.com/signalfx/opencensus-go-exporter-kinesis v0.6.3
 	github.com/stretchr/testify v1.6.1

--- a/exporter/kinesisexporter/marshaller.go
+++ b/exporter/kinesisexporter/marshaller.go
@@ -20,7 +20,10 @@ import (
 
 // Marshaller marshals traces/metrics into Message array.
 type Marshaller interface {
-	// MarshalMetrics serializes metrics into Messages
+	// MarshalTraces serializes traces into a byte array
+	MarshalTraces(traces pdata.Traces) ([]byte, error)
+
+	// MarshalMetrics serializes metrics into a byte array
 	MarshalMetrics(metrics pdata.Metrics) ([]byte, error)
 
 	// Encoding returns encoding name

--- a/exporter/kinesisexporter/otlp_marshaller.go
+++ b/exporter/kinesisexporter/otlp_marshaller.go
@@ -27,6 +27,10 @@ func (m *otlpProtoMarshaller) Encoding() string {
 	return otlpProto
 }
 
+func (m *otlpProtoMarshaller) MarshalTraces(traces pdata.Traces) ([]byte, error) {
+	return traces.ToOtlpProtoBytes()
+}
+
 func (m *otlpProtoMarshaller) MarshalMetrics(metrics pdata.Metrics) ([]byte, error) {
 	return metrics.ToOtlpProtoBytes()
 }

--- a/exporter/kinesisexporter/otlp_marshaller_test.go
+++ b/exporter/kinesisexporter/otlp_marshaller_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
@@ -38,3 +37,5 @@ func TestOTLPMetricsMarshaller(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expected, message)
 }
+
+// TODO add test for trace marshaling

--- a/exporter/kinesisexporter/testdata/config.yaml
+++ b/exporter/kinesisexporter/testdata/config.yaml
@@ -3,7 +3,7 @@ receivers:
 
 exporters:
   kinesis:
-    export_format: ""
+    encoding: ""
     aws:
         stream_name: test-stream
         region: mars-1


### PR DESCRIPTION
**Description:** 
* Integrated otlp marshaling into the trace exporting path
* Updated the marshaller interface to account for traces
* Updated comments to reflect the removal of the `Messages` struct