### PR TITLE
add tests and fix index overflow on Atlassian Fork

### DIFF
--- a/processor/spanmetricsprocessor/factory_test.go
+++ b/processor/spanmetricsprocessor/factory_test.go
@@ -16,6 +16,7 @@ package spanmetricsprocessor
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -41,9 +42,9 @@ func TestNewProcessor(t *testing.T) {
 			wantLatencyHistogramBuckets: defaultLatencyHistogramBucketsMs,
 		},
 		{
-			name:                        "latency histogram configured with catch-all bucket to check no additional catch-all bucket inserted",
-			latencyHistogramBuckets:     []time.Duration{2 * time.Millisecond, maxDuration},
-			wantLatencyHistogramBuckets: []float64{2, maxDurationMs},
+			name:                        "catch-all bucket always inserted even when specifying max value possible",
+			latencyHistogramBuckets:     []time.Duration{2 * time.Millisecond, time.Duration(math.MaxInt64)},
+			wantLatencyHistogramBuckets: []float64{2, durationToMillis(math.MaxInt64), maxDurationMs},
 		},
 		{
 			name:                    "full config with no catch-all bucket and check the catch-all bucket is inserted",

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -52,8 +52,7 @@ const (
 )
 
 var (
-	maxDuration   = time.Duration(math.MaxInt64)
-	maxDurationMs = durationToMillis(maxDuration)
+	maxDurationMs = math.MaxFloat64
 
 	defaultLatencyHistogramBucketsMs = []float64{
 		2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1000, 1400, 2000, 5000, 10_000, 15_000, maxDurationMs,
@@ -66,7 +65,7 @@ type exemplarData struct {
 }
 
 type aggregationMeta struct {
-	serviceName string
+	serviceName  string
 	instrLibName instrLibKey
 	resourceAttr pdata.AttributeMap
 }
@@ -131,10 +130,8 @@ func newProcessor(logger *zap.Logger, config config.Processor, nextConsumer cons
 	if pConfig.LatencyHistogramBuckets != nil {
 		bounds = mapDurationsToMillis(pConfig.LatencyHistogramBuckets)
 
-		// "Catch-all" bucket.
-		if bounds[len(bounds)-1] != maxDurationMs {
-			bounds = append(bounds, maxDurationMs)
-		}
+		// "Catch-all" bucket always appended
+		bounds = append(bounds, maxDurationMs)
 	}
 
 	if err := validateDimensions(pConfig.Dimensions, []string{spanKindKey, statusCodeKey}); err != nil {
@@ -452,7 +449,7 @@ func (p *processorImp) aggregateMetricsForServiceSpans(rspans pdata.ResourceSpan
 		for k := 0; k < spans.Len(); k++ {
 			span := spans.At(k)
 			aggrMeta := aggregationMeta{
-				serviceName: serviceName,
+				serviceName:  serviceName,
 				resourceAttr: rspans.Resource().Attributes(),
 				instrLibName: instrLibName,
 			}

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -308,9 +308,9 @@ func TestProcessorConsumeTraces(t *testing.T) {
 					startTime:  pdata.TimestampFromTime(time.Time{}),
 					// maximum seconds value that can be held by time.Time.
 					// Get maximum 64 int by shifting left by 1 and then taking the complement
-					// time.Unix adds (1969*365 + 1969/4 - 1969/100 + 1969/400) * 86400 == 62135638488 to the input value (see internal implementation) so we have to subtract that
+					// time.Unix adds 62135596800 to the input value (see internal implementation) so we have to subtract that
 					// to get the maximum value that time.Unix can take.
-					endTime: pdata.TimestampFromTime(time.Unix(1<<63-1-62135638488, 0)),
+					endTime: pdata.TimestampFromTime(time.Unix(1<<63-1-62135596800, 0)),
 				},
 				{
 					operation:  "/ping",
@@ -319,7 +319,7 @@ func TestProcessorConsumeTraces(t *testing.T) {
 					spanID:     pdata.NewSpanID([8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03}),
 					traceID:    pdata.NewTraceID([16]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}),
 					// maximum seconds value held by time.Time as explained above.
-					startTime: pdata.TimestampFromTime(time.Unix(1<<63-1-62135638488, 0)),
+					startTime: pdata.TimestampFromTime(time.Unix(1<<63-1-62135596800, 0)),
 					endTime:   pdata.TimestampFromTime(time.Time{}),
 				},
 			},

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -360,6 +360,7 @@ func TestProcessorConsumeTraces(t *testing.T) {
 		{
 			name:                   "Test maximum span time will not cause out of bounds index error",
 			aggregationTemporality: delta,
+			verifier:               verifyConsumeMetricsInputDelta,
 			traces:                 []pdata.Traces{spanWithLargeTimestamp},
 		},
 	}

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -90,6 +90,8 @@ type span struct {
 	statusCode pdata.StatusCode
 	spanID     pdata.SpanID
 	traceID    pdata.TraceID
+	startTime  pdata.Timestamp
+	endTime    pdata.Timestamp
 }
 
 func TestProcessorStart(t *testing.T) {
@@ -232,6 +234,38 @@ func TestProcessorConsumeTracesErrors(t *testing.T) {
 }
 
 func TestProcessorConsumeTracesConcurrentSafe(t *testing.T) {
+	spanWithLargeTimestamp := pdata.NewTraces()
+	initServiceSpans(
+		serviceSpans{
+			serviceName:                "service-b",
+			instrumentationLibraryName: "service-b-instrumentation-library",
+			spans: []span{
+				{
+					operation:  "/ping",
+					kind:       pdata.SpanKindServer,
+					statusCode: pdata.StatusCodeError,
+					spanID:     pdata.NewSpanID([8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03}),
+					traceID:    pdata.NewTraceID([16]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}),
+					startTime:  pdata.TimestampFromTime(time.Time{}),
+					// maximum seconds value that can be held by time.Time.
+					// Get maximum 64 int by shifting left by 1 and then taking the complement
+					// time.Unix adds (1969*365 + 1969/4 - 1969/100 + 1969/400) * 86400 == 62135638488 to the input value (see internal implementation) so we have to subtract that
+					// to get the maximum value that time.Unix can take.
+					endTime: pdata.TimestampFromTime(time.Unix(1<<63-62135596801, 0)),
+				},
+				{
+					operation:  "/ping",
+					kind:       pdata.SpanKindServer,
+					statusCode: pdata.StatusCodeError,
+					spanID:     pdata.NewSpanID([8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03}),
+					traceID:    pdata.NewTraceID([16]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}),
+					// maximum seconds value held by time.Time as explained above.
+					startTime: pdata.TimestampFromTime(time.Unix(1<<63-62135596801, 0)),
+					endTime:   pdata.TimestampFromTime(time.Time{}),
+				},
+			},
+		}, spanWithLargeTimestamp.ResourceSpans().AppendEmpty())
+
 	testcases := []struct {
 		name                   string
 		aggregationTemporality string
@@ -258,6 +292,11 @@ func TestProcessorConsumeTracesConcurrentSafe(t *testing.T) {
 			name:                   "Test two consumptions (Delta).",
 			aggregationTemporality: delta,
 			traces:                 []pdata.Traces{buildSampleTrace(), buildSampleTrace()},
+		},
+		{
+			name:                   "Test maximum span time will not cause out of bounds index error",
+			aggregationTemporality: delta,
+			traces:                 []pdata.Traces{spanWithLargeTimestamp},
 		},
 	}
 
@@ -860,6 +899,8 @@ func verifyMetricLabels(dp metricDataPoint, t testing.TB, seenMetricIDs map[metr
 //       service-b/ping (server)
 func buildSampleTrace() pdata.Traces {
 	traces := pdata.NewTraces()
+	spanStartTime := pdata.TimestampFromTime(time.Now())
+	spanEndTime := pdata.TimestampFromTime(time.Now().Add(sampleLatencyDuration))
 
 	initServiceSpans(
 		serviceSpans{
@@ -872,6 +913,8 @@ func buildSampleTrace() pdata.Traces {
 					statusCode: pdata.StatusCodeOk,
 					spanID:     pdata.NewSpanID([8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}),
 					traceID:    pdata.NewTraceID([16]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}),
+					startTime:  spanStartTime,
+					endTime:    spanEndTime,
 				},
 				{
 					operation:  "/ping",
@@ -879,6 +922,8 @@ func buildSampleTrace() pdata.Traces {
 					statusCode: pdata.StatusCodeOk,
 					spanID:     pdata.NewSpanID([8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}),
 					traceID:    pdata.NewTraceID([16]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}),
+					startTime:  spanStartTime,
+					endTime:    spanEndTime,
 				},
 			},
 		}, traces.ResourceSpans().AppendEmpty())
@@ -893,6 +938,8 @@ func buildSampleTrace() pdata.Traces {
 					statusCode: pdata.StatusCodeError,
 					spanID:     pdata.NewSpanID([8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03}),
 					traceID:    pdata.NewTraceID([16]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}),
+					startTime:  spanStartTime,
+					endTime:    spanEndTime,
 				},
 			},
 		}, traces.ResourceSpans().AppendEmpty())
@@ -922,9 +969,8 @@ func initSpan(span span, s pdata.Span) {
 	s.SetName(span.operation)
 	s.SetKind(span.kind)
 	s.Status().SetCode(span.statusCode)
-	now := time.Now()
-	s.SetStartTimestamp(pdata.TimestampFromTime(now))
-	s.SetEndTimestamp(pdata.TimestampFromTime(now.Add(sampleLatencyDuration)))
+	s.SetStartTimestamp(span.startTime)
+	s.SetEndTimestamp(span.endTime)
 	s.Attributes().InsertString(stringAttrName, "stringAttrValue")
 	s.Attributes().InsertInt(intAttrName, 99)
 	s.Attributes().InsertDouble(doubleAttrName, 99.99)

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -292,6 +292,10 @@ func TestProcessorConsumeTracesConcurrentSafe(t *testing.T) {
 	}
 }
 
+func verifyMetricsNoOp(t testing.TB, input pdata.Metrics, attachSpanAndTraceID bool, expectedSpanAndTraceIDs map[string]int) bool {
+	return true
+}
+
 func TestProcessorConsumeTraces(t *testing.T) {
 	spanWithLargeTimestamp := pdata.NewTraces()
 	initServiceSpans(
@@ -360,7 +364,7 @@ func TestProcessorConsumeTraces(t *testing.T) {
 		{
 			name:                   "Test maximum span time will not cause out of bounds index error",
 			aggregationTemporality: delta,
-			verifier:               nil,
+			verifier:               verifyMetricsNoOp,
 			traces:                 []pdata.Traces{spanWithLargeTimestamp},
 		},
 	}
@@ -375,11 +379,7 @@ func TestProcessorConsumeTraces(t *testing.T) {
 
 			// Mocked metric exporter will perform validation on metrics, during p.ConsumeTraces()
 			mexp.On("ConsumeMetrics", mock.Anything, mock.MatchedBy(func(input pdata.Metrics) bool {
-				if tc.verifier != nil {
-					return tc.verifier(t, input, false, make(map[string]int))
-				}
-
-				return true
+				return tc.verifier(t, input, false, make(map[string]int))
 			})).Return(nil)
 			tcon.On("ConsumeTraces", mock.Anything, mock.Anything).Return(nil)
 

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -292,10 +292,6 @@ func TestProcessorConsumeTracesConcurrentSafe(t *testing.T) {
 	}
 }
 
-func verifyMetricsNoOp(t testing.TB, input pdata.Metrics, attachSpanAndTraceID bool, expectedSpanAndTraceIDs map[string]int) bool {
-	return true
-}
-
 func TestProcessorConsumeTraces(t *testing.T) {
 	spanWithLargeTimestamp := pdata.NewTraces()
 	initServiceSpans(
@@ -364,8 +360,10 @@ func TestProcessorConsumeTraces(t *testing.T) {
 		{
 			name:                   "Test maximum span time will not cause out of bounds index error",
 			aggregationTemporality: delta,
-			verifier:               verifyMetricsNoOp,
-			traces:                 []pdata.Traces{spanWithLargeTimestamp},
+			verifier: func(t testing.TB, input pdata.Metrics, attachSpanAndTraceID bool, expectedSpanAndTraceIDs map[string]int) bool {
+				return true
+			},
+			traces: []pdata.Traces{spanWithLargeTimestamp},
 		},
 	}
 

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -899,8 +899,9 @@ func verifyMetricLabels(dp metricDataPoint, t testing.TB, seenMetricIDs map[metr
 //       service-b/ping (server)
 func buildSampleTrace() pdata.Traces {
 	traces := pdata.NewTraces()
-	spanStartTime := pdata.TimestampFromTime(time.Now())
-	spanEndTime := pdata.TimestampFromTime(time.Now().Add(sampleLatencyDuration))
+	now := time.Now()
+	spanStartTime := pdata.TimestampFromTime(now)
+	spanEndTime := pdata.TimestampFromTime(now.Add(sampleLatencyDuration))
 
 	initServiceSpans(
 		serviceSpans{


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This fixes the bug outlined [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7250) by ensuring that we are comparing float64s. Since the time.Duration value is represented by an int64 in the underlying implementation, this means we'll always need to append the `math.maxFloat64` value as the "infinity bucket" no matter what the user specifies.

In theory we shouldn't encounter this bug since it requires a span with a very large timestamp but it'll be good to fix it to be safe.

**Testing:** Adds in tests that would catch that case and throw an index out of bounds error

**Documentation:** N/A - internal fix