### PR TITLE
Fix bucket counts length

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -569,7 +569,7 @@ func (p *processorImp) updateLatencyMetrics(rKey resourceKey, mKey metricKey, la
 		p.latencyBucketCounts[rKey][instrLibName] = make(map[metricKey][]uint64)
 	}
 	if _, ok := p.latencyBucketCounts[rKey][instrLibName][mKey]; !ok {
-		p.latencyBucketCounts[rKey][instrLibName][mKey] = make([]uint64, len(p.latencyBounds))
+		p.latencyBucketCounts[rKey][instrLibName][mKey] = make([]uint64, len(p.latencyBounds) + 1)
 	}
 	p.latencyBucketCounts[rKey][instrLibName][mKey][index]++
 

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -916,6 +916,10 @@ func verifyMetrics(m pdata.MetricSlice, expectedTemporality pdata.AggregationTem
 			}
 			assert.Equal(t, wantBucketCount, dp.BucketCounts()[bi])
 		}
+
+		// Then verify len(bucketCounts) == len(ExplicitBounds) + 1
+		assert.Equal(t, len(dp.ExplicitBounds()) +1, len(dp.BucketCounts()))
+
 		verifyMetricLabels(dp, t, seenMetricIDs, attachSpanAndTraceID, expectedSpanAndTraceIDs)
 	}
 }


### PR DESCRIPTION
the bucketCount slice length should be len(ExplicitBounds) + 1.

e.g.:
```
ExplicitBounds [0,10,100] ==> bucketCount with range (-inf, 0] , (0, 10] , (10, 100],  (100, +int] 

With ExplicitBounds [0,10,100], the histogram bucketCount will be like:

-1 ==> [0, 0, 0, 0]

0 ==> [1, 0, 0, 0]

5 => [0, 1, 0, 0]

10 ==> [0, 1, 0, 0]

100 ==>  [0, 0, 1, 0]

1000  ==> [0, 0, 0, 1]
```

ref: https://opentelemetry.io/docs/reference/specification/metrics/datamodel/#histogram

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>
https://atlassian.slack.com/archives/C010T25NBNV/p1643776783257789?thread_ts=1643755762.143159&cid=C010T25NBNV

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>