### PR TITLE
Metric renaming also requires attribute value to be matched on via regex

### DIFF
--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -83,6 +83,8 @@ The following settings can be optionally configured:
 
 - `launch_darkly_key`: defines the LaunchDarkly key. Optional. Only required when `EnableFeatureFlag` is `true`.
 
+- `renames`: defines the rules in which a metric should be renamed, based off attribute key value pairs that match. Optional. By default, metric names are `calls_total` and `latency`.
+
 ## Examples
 
 The following is a simple example usage of the spanmetrics processor.
@@ -126,7 +128,13 @@ processors:
       - name: host_id
     resource_attributes_cache_size: 1000
     aggregation_temporality: "AGGREGATION_TEMPORALITY_DELTA"    
-    inherit_instrumentation_library_name: true 
+    inherit_instrumentation_library_name: true
+    renames:
+      - attributes:
+        - attribute: http.method
+          attribute_value_regex: ".*"
+        new_calls_total_metric_name: http.server.requests
+        new_latency_metric_name: latency
 
 exporters:
   jaeger:

--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -131,7 +131,8 @@ processors:
     inherit_instrumentation_library_name: true
     renames:
       - attributes:
-        - attribute: http.method
+        - attribute:
+            name: http.method
           attribute_value_regex: ".*"
         new_calls_total_metric_name: http.server.requests
         new_latency_metric_name: http.server.duration

--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -134,7 +134,7 @@ processors:
         - attribute: http.method
           attribute_value_regex: ".*"
         new_calls_total_metric_name: http.server.requests
-        new_latency_metric_name: latency
+        new_latency_metric_name: http.server.duration
 
 exporters:
   jaeger:

--- a/processor/spanmetricsprocessor/config.go
+++ b/processor/spanmetricsprocessor/config.go
@@ -105,8 +105,8 @@ type Rename struct {
 }
 
 type AttributeRenameMatchValues struct {
-	Attribute           Dimension
-	AttributeValueRegex string
+	Attribute           Dimension `mapstructure:"attribute"`
+	AttributeValueRegex string    `mapstructure:"attribute_value_regex"`
 }
 
 type internalRename struct {

--- a/processor/spanmetricsprocessor/config.go
+++ b/processor/spanmetricsprocessor/config.go
@@ -15,6 +15,7 @@
 package spanmetricsprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor"
 
 import (
+	"fmt"
 	"regexp"
 	"time"
 
@@ -108,6 +109,20 @@ type AttributeRenameMatchValues struct {
 	Attribute              Dimension `mapstructure:"attribute"`
 	AttributeValueRegex    string    `mapstructure:"attribute_value_regex"`
 	AttributeValueRegexObj *regexp.Regexp
+}
+
+func (r *Rename) buildRegex() error {
+	for renameMatchValIndex, attributeRenameMatchVal := range r.Attributes {
+		regexObj, err := regexp.Compile(attributeRenameMatchVal.AttributeValueRegex)
+		// should never happen as `validateRenames` function validates for errors
+		if err != nil {
+			return fmt.Errorf("renames: invalid regex specified for attribute key %s", attributeRenameMatchVal.Attribute.Name)
+		}
+
+		r.Attributes[renameMatchValIndex].AttributeValueRegexObj = regexObj
+	}
+
+	return nil
 }
 
 func (r Rename) allAttributesKVMatched(attributesOnMetric *pdata.AttributeMap) bool {

--- a/processor/spanmetricsprocessor/config.go
+++ b/processor/spanmetricsprocessor/config.go
@@ -99,23 +99,23 @@ type Config struct {
 // `NewCallsTotalMetricName` and `NewLatencyMetricName` are mandatory arguments that can not be empty.
 // If no attributes are specified, then all metrics will be caught under this case and renamed.
 type Rename struct {
-	Attributes              []AttributeRename `mapstructure:"attributes"`
-	NewCallsTotalMetricName string            `mapstructure:"new_calls_total_metric_name"`
-	NewLatencyMetricName    string            `mapstructure:"new_latency_metric_name"`
+	Attributes              []AttributeRenameMatchValues `mapstructure:"attributes"`
+	NewCallsTotalMetricName string                       `mapstructure:"new_calls_total_metric_name"`
+	NewLatencyMetricName    string                       `mapstructure:"new_latency_metric_name"`
 }
 
-type AttributeRename struct {
+type AttributeRenameMatchValues struct {
 	Attribute           Dimension
 	AttributeValueRegex string
 }
 
 type internalRename struct {
-	Attributes              []internalAttributeRename
+	Attributes              []internalAttributeRenameMatchValues
 	NewCallsTotalMetricName string
 	NewLatencyMetricName    string
 }
 
-type internalAttributeRename struct {
+type internalAttributeRenameMatchValues struct {
 	Attribute           Dimension
 	AttributeValueRegex *regexp.Regexp
 }

--- a/processor/spanmetricsprocessor/config.go
+++ b/processor/spanmetricsprocessor/config.go
@@ -105,22 +105,12 @@ type Rename struct {
 }
 
 type AttributeRenameMatchValues struct {
-	Attribute           Dimension `mapstructure:"attribute"`
-	AttributeValueRegex string    `mapstructure:"attribute_value_regex"`
+	Attribute              Dimension `mapstructure:"attribute"`
+	AttributeValueRegex    string    `mapstructure:"attribute_value_regex"`
+	AttributeValueRegexObj *regexp.Regexp
 }
 
-type internalRename struct {
-	Attributes              []internalAttributeRenameMatchValues
-	NewCallsTotalMetricName string
-	NewLatencyMetricName    string
-}
-
-type internalAttributeRenameMatchValues struct {
-	Attribute           Dimension
-	AttributeValueRegex *regexp.Regexp
-}
-
-func (r internalRename) allAttributesMatched(attributesOnMetric *pdata.AttributeMap) bool {
+func (r Rename) allAttributesKVMatched(attributesOnMetric *pdata.AttributeMap) bool {
 	// If no attribute specified then it is the default/ catch-all case
 	if len(r.Attributes) == 0 {
 		return true
@@ -136,7 +126,7 @@ func (r internalRename) allAttributesMatched(attributesOnMetric *pdata.Attribute
 		}
 
 		//check if value matches specified regex
-		matched := attribute.AttributeValueRegex.Match([]byte(value.StringVal()))
+		matched := attribute.AttributeValueRegexObj.Match([]byte(value.StringVal()))
 		if !matched {
 			return false
 		}

--- a/processor/spanmetricsprocessor/config_test.go
+++ b/processor/spanmetricsprocessor/config_test.go
@@ -50,6 +50,7 @@ func TestLoadConfig(t *testing.T) {
 		wantInheritInstrumentationLibraryName bool
 		wantEnableFeatureFlag                 bool
 		wantLaunchDarklyKey                   string
+		wantRenames                           []Rename
 	}{
 		{
 			configFile:                            "config-2-pipelines.yaml",
@@ -100,6 +101,20 @@ func TestLoadConfig(t *testing.T) {
 			wantInheritInstrumentationLibraryName: false,
 			wantEnableFeatureFlag:                 false,
 			wantLaunchDarklyKey:                   "",
+			wantRenames: []Rename{
+				{
+					Attributes: []AttributeRenameMatchValues{
+						{
+							Attribute: Dimension{
+								Name: "http.method",
+							},
+							AttributeValueRegex: ".*",
+						},
+					},
+					NewCallsTotalMetricName: "http.server.requests",
+					NewLatencyMetricName:    "http.server.duration",
+				},
+			},
 		},
 	}
 	for _, tc := range testcases {
@@ -140,6 +155,7 @@ func TestLoadConfig(t *testing.T) {
 					InheritInstrumentationLibraryName: tc.wantInheritInstrumentationLibraryName,
 					EnableFeatureFlag:                 tc.wantEnableFeatureFlag,
 					LaunchDarklyKey:                   tc.wantLaunchDarklyKey,
+					Renames:                           tc.wantRenames,
 				},
 				cfg.Processors[config.NewID(typeStr)],
 			)

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -154,8 +154,12 @@ func newProcessor(logger *zap.Logger, config config.Processor, nextConsumer cons
 		return nil, err
 	}
 
-	internalRename, err := buildInternalRename(pConfig.Renames)
 	if err := validateRenames(pConfig.Renames); err != nil {
+		return nil, err
+	}
+
+	internalRename, err := buildInternalRename(pConfig.Renames)
+	if err != nil {
 		return nil, err
 	}
 
@@ -271,8 +275,6 @@ func buildInternalRename(renames []Rename) ([]internalRename, error) {
 
 		internalRenames = append(internalRenames, newInternalRename)
 	}
-
-	// regexStrToObj := make(map[string]*regexp.Regexp)
 
 	return internalRenames, nil
 }

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -248,7 +248,7 @@ func buildInternalRename(renames []Rename) ([]internalRename, error) {
 	var internalRenames []internalRename
 
 	for _, rename := range renames {
-		newInternalAttributeRename := make([]internalAttributeRename, len(rename.Attributes))
+		newInternalAttributeRenameMatchValues := make([]internalAttributeRenameMatchValues, len(rename.Attributes))
 		for _, attribute := range rename.Attributes {
 			regexObj, err := regexp.Compile(attribute.AttributeValueRegex)
 			// should never happen as `validateRenames` function validates for errors
@@ -257,14 +257,14 @@ func buildInternalRename(renames []Rename) ([]internalRename, error) {
 			}
 
 			// newInternalAttributeRename.regex = regexObj
-			append(newInternalAttributeRename, internalAttributeRename{
+			append(newInternalAttributeRenameMatchValues, internalAttributeRenameMatchValues) {
 				attribute.Attribute,
 				regexObj,
 			})
 		}
 
 		newInternalRename := internalRename{
-			Attributes:              newInternalAttributeRename,
+			Attributes:              newInternalAttributeRenameMatchValues,
 			NewCallsTotalMetricName: rename.NewCallsTotalMetricName,
 			NewLatencyMetricName:    rename.NewLatencyMetricName,
 		}

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -256,8 +256,8 @@ func buildInternalRename(renames []Rename) ([]internalRename, error) {
 				return nil, fmt.Errorf("renames: invalid regex specified for attribute key %s", attribute.Attribute.Name)
 			}
 
-			// newInternalAttributeRename.regex = regexObj
-			append(newInternalAttributeRenameMatchValues, internalAttributeRenameMatchValues) {
+			// build rename structure with regex object
+			newInternalAttributeRenameMatchValues = append(newInternalAttributeRenameMatchValues, internalAttributeRenameMatchValues{
 				attribute.Attribute,
 				regexObj,
 			})

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -978,7 +978,7 @@ func verifyMetrics(m pdata.MetricSlice, expectedTemporality pdata.AggregationTem
 		}
 
 		// Then verify len(bucketCounts) == len(ExplicitBounds) + 1
-		assert.Equal(t, len(dp.ExplicitBounds()) +1, len(dp.BucketCounts()))
+		assert.Equal(t, len(dp.ExplicitBounds())+1, len(dp.BucketCounts()))
 
 		verifyMetricLabels(dp, t, seenMetricIDs, attachSpanAndTraceID, expectedSpanAndTraceIDs)
 	}

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -1724,11 +1724,6 @@ func TestBuildRegex(t *testing.T) {
 	require.Equal(t, matchAllRegex.String(), renames[0].Attributes[0].AttributeValueRegexObj.String())
 	require.Equal(t, matchAllRegex.String(), renames[0].Attributes[1].AttributeValueRegexObj.String())
 	require.Equal(t, matchSpecificRegex.String(), renames[1].Attributes[0].AttributeValueRegexObj.String())
-	// for _, rename := range renames {
-	// 	for _, attribute := range rename.Attributes {
-	// 		require.NotEmpty(t, attribute.AttributeValueRegexObj)
-	// 	}
-	// }
 }
 
 func TestFeatureFlag(t *testing.T) {

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -1675,6 +1675,62 @@ func TestValidateDimensions(t *testing.T) {
 	}
 }
 
+func TestBuildRegex(t *testing.T) {
+	matchAllRegex, err := regexp.Compile(".*")
+	if err != nil {
+		panic(err)
+	}
+	matchSpecificRegex, err := regexp.Compile("abc123")
+	if err != nil {
+		panic(err)
+	}
+
+	renames := []Rename{
+		{
+			Attributes: []AttributeRenameMatchValues{
+				{
+					Attribute: Dimension{
+						Name: "dim1",
+					},
+					AttributeValueRegex: ".*",
+				},
+				{
+					Attribute: Dimension{
+						Name: "dim2",
+					},
+					AttributeValueRegex: ".*",
+				},
+			},
+		},
+		{
+			Attributes: []AttributeRenameMatchValues{
+				{
+					Attribute: Dimension{
+						Name: "dim3",
+					},
+					AttributeValueRegex: "abc123",
+				},
+			},
+		},
+	}
+
+	for _, rename := range renames {
+		err := rename.buildRegex()
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	require.Equal(t, matchAllRegex.String(), renames[0].Attributes[0].AttributeValueRegexObj.String())
+	require.Equal(t, matchAllRegex.String(), renames[0].Attributes[1].AttributeValueRegexObj.String())
+	require.Equal(t, matchSpecificRegex.String(), renames[1].Attributes[0].AttributeValueRegexObj.String())
+	// for _, rename := range renames {
+	// 	for _, attribute := range rename.Attributes {
+	// 		require.NotEmpty(t, attribute.AttributeValueRegexObj)
+	// 	}
+	// }
+}
+
 func TestFeatureFlag(t *testing.T) {
 	// Prepare
 	mexp := &mocks.MetricsExporter{}

--- a/processor/spanmetricsprocessor/testdata/config-full.yaml
+++ b/processor/spanmetricsprocessor/testdata/config-full.yaml
@@ -70,6 +70,15 @@ processors:
     # The aggregation temporality of the generated metrics.
     # Default: "AGGREGATION_TEMPORALITY_CUMULATIVE"
     aggregation_temporality: "AGGREGATION_TEMPORALITY_DELTA"
+    # rename any metrics with http.method attribute key to `http.server.requests` and `http.server.duration`
+    # for `calls_total` and `latency` metrics respectively
+    renames:
+      - attributes:
+        - attribute:
+            name: http.method
+          attribute_value_regex: ".*"
+        new_calls_total_metric_name: http.server.requests
+        new_latency_metric_name: http.server.duration
 
 service:
   pipelines:


### PR DESCRIPTION
Adds in ability to specify value to regex match on. 

use case: for example, http.server and http.client metrics can only be differentiated by the span kind field value.

Added in documentation to readme
Fixed up Testing.
